### PR TITLE
Compatibility with more recent versions of Data:Printer

### DIFF
--- a/lib/Devel/PrettyTrace.pm
+++ b/lib/Devel/PrettyTrace.pm
@@ -18,6 +18,9 @@ our $Skiplevels = 0;
 our %IgnorePkg;
 our %Opts = (
     colored		=> 1,
+    colors		=> {
+	    brackets    => ''
+    },
     class 		=> {
         internals       => 1,
         show_methods    => 'none',

--- a/t/02_colors.t
+++ b/t/02_colors.t
@@ -6,11 +6,10 @@ use Devel::PrettyTrace;
 $Devel::PrettyTrace::Opts{show_readonly} = 0;
 $Devel::PrettyTrace::Opts{colors}{array} = 'bright_white';
 $Devel::PrettyTrace::Opts{colors}{number} = 'bright_blue';
-$Devel::PrettyTrace::Opts{colors}{brackets} = '';
 
 sub f{bt}
 
 is(f(1), '  main::f(
     '.colored('[0] ', 'bright_white').colored(1, 'bright_blue').'
-  ) called at t/02_colors.t line 13
+  ) called at t/02_colors.t line 12
 ');

--- a/t/02_colors.t
+++ b/t/02_colors.t
@@ -3,10 +3,14 @@ use Test::More tests => 1;
 delete $ENV{ANSI_COLORS_DISABLED};
 use Term::ANSIColor;
 use Devel::PrettyTrace;
+$Devel::PrettyTrace::Opts{show_readonly} = 0;
+$Devel::PrettyTrace::Opts{colors}{array} = 'bright_white';
+$Devel::PrettyTrace::Opts{colors}{number} = 'bright_blue';
+$Devel::PrettyTrace::Opts{colors}{brackets} = '';
 
 sub f{bt}
 
 is(f(1), '  main::f(
     '.colored('[0] ', 'bright_white').colored(1, 'bright_blue').'
-  ) called at t/02_colors.t line 9
+  ) called at t/02_colors.t line 13
 ');

--- a/t/03_traces.t
+++ b/t/03_traces.t
@@ -1,7 +1,8 @@
-use Test::More tests => 4;
+use Test::More;
 
 use Devel::PrettyTrace;
 $Devel::PrettyTrace::Opts{colored} = 0;
+$Devel::PrettyTrace::Opts{show_readonly} = 0;
 
 sub z{
 	bt;
@@ -20,10 +21,10 @@ is($z->(), '  main::z(
     [0] 1,
     [1] 2,
     [2] "t"
-  ) called at t/03_traces.t line 13
-  Z::__ANON__() called at t/03_traces.t line 14
-  main::f() called at t/03_traces.t line 17
-  main::__ANON__() called at t/03_traces.t line 19
+  ) called at t/03_traces.t line 14
+  Z::__ANON__() called at t/03_traces.t line 15
+  main::f() called at t/03_traces.t line 18
+  main::__ANON__() called at t/03_traces.t line 20
 ');
 
 {
@@ -33,17 +34,17 @@ is($z->(), '  main::z(
     [0] 1,
     [1] 2,
     [2] "t"
-  ) called at t/03_traces.t line 13
-  Z::__ANON__() called at t/03_traces.t line 14
+  ) called at t/03_traces.t line 14
+  Z::__ANON__() called at t/03_traces.t line 15
 ');
 }
 
 {
     local $Devel::PrettyTrace::Skiplevels = 1;
 
-	is($z->(), '  Z::__ANON__() called at t/03_traces.t line 14
-  main::f() called at t/03_traces.t line 17
-  main::__ANON__() called at t/03_traces.t line 44
+	is($z->(), '  Z::__ANON__() called at t/03_traces.t line 15
+  main::f() called at t/03_traces.t line 18
+  main::__ANON__() called at t/03_traces.t line 45
 ');
 }
 
@@ -54,8 +55,9 @@ is($z->(), '  main::z(
     [0] 1,
     [1] 2,
     [2] "t"
-  ) called at t/03_traces.t line 13
-  main::f() called at t/03_traces.t line 17
-  main::__ANON__() called at t/03_traces.t line 53
+  ) called at t/03_traces.t line 14
+  main::f() called at t/03_traces.t line 18
+  main::__ANON__() called at t/03_traces.t line 54
 ');
 }
+done_testing;

--- a/t/04_begin.t
+++ b/t/04_begin.t
@@ -14,10 +14,9 @@ $f =~ s/eval \d+/eval/g;
 
 like($f, qr!\Q  main::z() called at t/inc/Foo.pm line 4
   Foo::import(
-    [0] "Foo"
+    [0] "Foo"\E(?: \(read-only\))?\Q
   ) called at (eval) line \E\d\Q
   main::BEGIN() called at \E[^ ]+\Q line \E\d\Q
   eval {...} called at \E[^ ]+\Q line \E\d\Q
   eval 'use Foo\E;?\Q' called at t/04_begin.t line 12
 \E!s);
-


### PR DESCRIPTION
I noticed that tests will start failing if a version of Data::Printer >= 1 is installed. This is because Data::Printer will use different colors and color things it didn't color before.
So the first commit fixes the tests to work with newer and older version of Data::Printer (I used 0.40. and  1.000004). And the second commit fixes Devel::PrettyTrace itself as it was not able to snip of the closing "]" around function arguments if Data::Printer colored brackets.
